### PR TITLE
Add unit tests for utility functions

### DIFF
--- a/src/utils/common.test.ts
+++ b/src/utils/common.test.ts
@@ -1,0 +1,284 @@
+import { getUniqueValues, groupBy } from './common';
+
+describe('getUniqueValues', () => {
+  // Test scenarios for primitives without key
+  describe('primitives without key (only strings are kept)', () => {
+    it('should return unique strings from an array of strings with duplicates', () => {
+      const arr = ['apple', 'banana', 'orange', 'apple', 'banana'];
+      expect(getUniqueValues(arr)).toEqual(['apple', 'banana', 'orange']);
+    });
+
+    it('should return an empty array from an array of numbers with duplicates (as numbers are filtered out)', () => {
+      const arr = [1, 2, 3, 1, 2];
+      expect(getUniqueValues(arr)).toEqual([]);
+    });
+
+    it('should return unique strings from an array of mixed strings and numbers (numbers filtered out)', () => {
+      const arr = ['apple', 1, 'banana', 2, 'apple', 1];
+      expect(getUniqueValues(arr)).toEqual(['apple', 'banana']);
+    });
+
+    it('should return the same array if all strings are unique', () => {
+      const arr = ['apple', 'banana', 'orange'];
+      expect(getUniqueValues(arr)).toEqual(['apple', 'banana', 'orange']);
+    });
+
+    it('should return unique values if all strings are duplicates', () => {
+      const arr = ['apple', 'apple', 'apple'];
+      expect(getUniqueValues(arr)).toEqual(['apple']);
+    });
+
+    it('should return an empty array if input is an empty array', () => {
+      const arr: string[] = [];
+      expect(getUniqueValues(arr)).toEqual([]);
+    });
+
+    it('should handle null and undefined values (they are filtered out)', () => {
+      const arr = ['apple', null, 'banana', undefined, 'apple', null];
+      expect(getUniqueValues(arr)).toEqual(['apple', 'banana']);
+    });
+  });
+
+  // Test scenarios for objects with key
+  describe('objects with key (keeps first occurrence, key must be string/number, order is reverse of last key appearance)', () => {
+    it('should return unique objects based on a string key, keeping first occurrences', () => {
+      const arr = [
+        { id: '1', name: 'apple' }, // First '1'
+        { id: '2', name: 'banana' },
+        { id: '1', name: 'orange' }, // This '1' is a duplicate
+      ];
+      // Order is reverse of last unique key appearance: '2' (from index 1) then '1' (from index 2, taking first item for '1')
+      expect(getUniqueValues(arr, 'id')).toEqual([
+        { id: '2', name: 'banana' },
+        { id: '1', name: 'apple' },
+      ]);
+    });
+
+    it('should return unique objects based on a number key, keeping first occurrences', () => {
+      const arr = [
+        { id: 1, name: 'apple' }, // First 1
+        { id: 2, name: 'banana' },
+        { id: 1, name: 'orange' }, // This 1 is a duplicate
+      ];
+      // Order is reverse of last unique key appearance: 2 (from index 1) then 1 (from index 2, taking first item for 1)
+      expect(getUniqueValues(arr, 'id')).toEqual([
+        { id: 2, name: 'banana' },
+        { id: 1, name: 'apple' },
+      ]);
+    });
+
+    it('should keep the first occurrence of an object with a duplicate key', () => {
+      const arr = [
+        { id: '1', value: 'first' }, // This is kept
+        { id: '2', value: 'second' },
+        { id: '1', value: 'third' }, // This is a duplicate of '1'
+      ];
+      // Order is reverse of last unique key appearance: '2' (from index 1) then '1' (from index 2, taking first item for '1')
+      expect(getUniqueValues(arr, 'id')).toEqual([
+        { id: '2', value: 'second' },
+        { id: '1', value: 'first' },
+      ]);
+    });
+
+    it('should return the same array if all key values are unique', () => {
+      const arr = [
+        { id: '1', name: 'apple' },
+        { id: '2', name: 'banana' },
+        { id: '3', name: 'orange' },
+      ];
+      expect(getUniqueValues(arr, 'id')).toEqual(arr);
+    });
+
+    it('should return the first object if all key values are the same', () => {
+      const arr = [
+        { id: '1', name: 'apple' }, // This is kept
+        { id: '1', name: 'banana' },
+        { id: '1', name: 'orange' },
+      ];
+      expect(getUniqueValues(arr, 'id')).toEqual([{ id: '1', name: 'apple' }]);
+    });
+
+    it('should return an empty array if input is an empty array (objects)', () => {
+      const arr: { id: string; name: string }[] = [];
+      expect(getUniqueValues(arr, 'id')).toEqual([]);
+    });
+
+    it('should skip objects where the specified key is not present (value is undefined)', () => {
+      const arr = [
+        { id: '1', name: 'apple' },
+        { name: 'banana' },
+        { id: '1', name: 'orange' },
+      ] as any[];
+      expect(getUniqueValues(arr, 'id')).toEqual([
+        { id: '1', name: 'apple' },
+      ]);
+    });
+
+    it('should skip objects where the key value is not a string or number (e.g. object)', () => {
+      const arrWithObjectKey = [
+        { id: { key: '1' }, name: 'apple' },
+        { id: { key: '2' }, name: 'banana' },
+        { id: { key: '1' }, name: 'orange' },
+      ];
+      expect(getUniqueValues(arrWithObjectKey, 'id')).toEqual([]);
+
+      const keyObj = { key: '1' };
+      const arrWithSameKeyInstance = [
+        { id: keyObj, name: 'apple' },
+        { id: { key: '2' }, name: 'banana' },
+        { id: keyObj, name: 'orange' },
+      ];
+      expect(getUniqueValues(arrWithSameKeyInstance, 'id')).toEqual([]);
+    });
+  });
+});
+
+describe('groupBy', () => {
+  interface TestObject {
+    id?: number | string;
+    category?: string | null | undefined | object;
+    value: string;
+  }
+
+  const sampleObjects: TestObject[] = [
+    { id: 1, category: 'A', value: 'Apple' },
+    { id: 2, category: 'B', value: 'Banana' },
+    { id: 3, category: 'A', value: 'Artichoke' },
+    { id: 4, category: 'C', value: 'Cherry' },
+    { id: 5, category: 'B', value: 'Blueberry' },
+  ];
+
+  describe('basic grouping', () => {
+    it('should group an array of objects by a string key (category)', () => {
+      const grouped = groupBy(sampleObjects, 'category');
+      expect(grouped['A']).toEqual([
+        { id: 1, category: 'A', value: 'Apple' },
+        { id: 3, category: 'A', value: 'Artichoke' },
+      ]);
+      expect(grouped['B']).toEqual([
+        { id: 2, category: 'B', value: 'Banana' },
+        { id: 5, category: 'B', value: 'Blueberry' },
+      ]);
+      expect(grouped['C']).toEqual([{ id: 4, category: 'C', value: 'Cherry' }]);
+    });
+
+    it('should group an array of objects by a number key (id), converting keys to strings', () => {
+      const idObjects: TestObject[] = [
+        { id: 1, value: 'Item 1' },
+        { id: 2, value: 'Item 2' },
+        { id: 1, value: 'Item 1 Dupe' },
+      ];
+      const grouped = groupBy(idObjects, 'id');
+      expect(grouped['1']).toEqual([
+        { id: 1, value: 'Item 1' },
+        { id: 1, value: 'Item 1 Dupe' },
+      ]);
+      expect(grouped['2']).toEqual([{ id: 2, value: 'Item 2' }]);
+    });
+  });
+
+  describe('content of groups', () => {
+    it('should ensure all items belonging to a group key are present', () => {
+      const grouped = groupBy(sampleObjects, 'category');
+      expect(grouped['A'].length).toBe(2);
+      expect(grouped['A']).toContainEqual({ id: 1, category: 'A', value: 'Apple' });
+      expect(grouped['A']).toContainEqual({ id: 3, category: 'A', value: 'Artichoke' });
+
+      expect(grouped['B'].length).toBe(2);
+      expect(grouped['B']).toContainEqual({ id: 2, category: 'B', value: 'Banana' });
+      expect(grouped['B']).toContainEqual({ id: 5, category: 'B', value: 'Blueberry' });
+    });
+
+    it('should ensure items not belonging to a group key are not present', () => {
+      const grouped = groupBy(sampleObjects, 'category');
+      expect(grouped['A']).not.toContainEqual({ id: 2, category: 'B', value: 'Banana' });
+      expect(grouped['C']).not.toContainEqual({ id: 1, category: 'A', value: 'Apple' });
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should return an empty object when grouping an empty array', () => {
+      const emptyArr: TestObject[] = [];
+      expect(groupBy(emptyArr, 'category')).toEqual({});
+    });
+
+    it('should group all items under one key if they all have the same value for the grouping key', () => {
+      const sameCategoryObjects: TestObject[] = [
+        { category: 'X', value: 'Item 1' },
+        { category: 'X', value: 'Item 2' },
+        { category: 'X', value: 'Item 3' },
+      ];
+      const grouped = groupBy(sameCategoryObjects, 'category');
+      expect(Object.keys(grouped).length).toBe(1);
+      expect(grouped['X']).toEqual(sameCategoryObjects);
+    });
+
+    it('should group items into individual keys if they all have different values for the grouping key', () => {
+      const differentCategoryObjects: TestObject[] = [
+        { category: 'P', value: 'Plum' },
+        { category: 'Q', value: 'Quince' },
+        { category: 'R', value: 'Raspberry' },
+      ];
+      const grouped = groupBy(differentCategoryObjects, 'category');
+      expect(Object.keys(grouped).length).toBe(3);
+      expect(grouped['P']).toEqual([{ category: 'P', value: 'Plum' }]);
+      expect(grouped['Q']).toEqual([{ category: 'Q', value: 'Quince' }]);
+      expect(grouped['R']).toEqual([{ category: 'R', value: 'Raspberry' }]);
+    });
+
+    it('should handle items missing the grouping key (key becomes "undefined")', () => {
+      const missingKeyObjects: TestObject[] = [
+        { category: 'A', value: 'Item 1' },
+        { value: 'Item 2 (no category)' }, // category is undefined
+        { category: 'A', value: 'Item 3' },
+      ];
+      const grouped = groupBy(missingKeyObjects, 'category');
+      expect(grouped['A']).toEqual([
+        { category: 'A', value: 'Item 1' },
+        { category: 'A', value: 'Item 3' },
+      ]);
+      expect(grouped['undefined']).toEqual([{ value: 'Item 2 (no category)' }]);
+    });
+
+    it('should handle null or undefined as grouping key values (keys become "null" or "undefined")', () => {
+      const nullUndefinedKeyObjects: TestObject[] = [
+        { category: 'A', value: 'Item 1' },
+        { category: null, value: 'Item 2 (null category)' },
+        { category: undefined, value: 'Item 3 (undefined category)' },
+        { category: 'A', value: 'Item 4' },
+        { category: null, value: 'Item 5 (null category)' },
+      ];
+      const grouped = groupBy(nullUndefinedKeyObjects, 'category');
+      expect(grouped['A']).toEqual([
+        { category: 'A', value: 'Item 1' },
+        { category: 'A', value: 'Item 4' },
+      ]);
+      expect(grouped['null']).toEqual([
+        { category: null, value: 'Item 2 (null category)' },
+        { category: null, value: 'Item 5 (null category)' },
+      ]);
+      expect(grouped['undefined']).toEqual([
+        { category: undefined, value: 'Item 3 (undefined category)' },
+      ]);
+    });
+
+    it('should handle object as grouping key value (key becomes string representation like "[object Object]")', () => {
+        const objKey = { type: 'complex' };
+        const objectKeyObjects: TestObject[] = [
+          { category: 'A', value: 'Item 1' },
+          { category: objKey, value: 'Item 2 (object category)' },
+          { category: 'A', value: 'Item 3' },
+        ];
+        const grouped = groupBy(objectKeyObjects, 'category');
+        expect(grouped['A']).toEqual([
+            { category: 'A', value: 'Item 1' },
+            { category: 'A', value: 'Item 3' },
+        ]);
+        // The key will be the string representation of the object
+        expect(grouped[String(objKey)]).toEqual([
+            { category: objKey, value: 'Item 2 (object category)' }
+        ]);
+        expect(grouped['[object Object]']).toBeDefined(); // General check
+      });
+  });
+});

--- a/src/utils/get_color_for_number.test.ts
+++ b/src/utils/get_color_for_number.test.ts
@@ -1,0 +1,131 @@
+import { getColorForNumber, Range } from './get_color_for_number';
+
+describe('getColorForNumber', () => {
+  const sampleRanges: Range[] = [
+    { start: 0, color: 'blue' },
+    { start: 10, color: 'green' },
+    { start: 20, color: 'red' },
+  ];
+
+  const sampleRangesWithNegatives: Range[] = [
+    { start: -20, color: 'purple' },
+    { start: -10, color: 'orange' },
+    { start: 0, color: 'yellow' },
+  ];
+
+  describe('basic functionality', () => {
+    it('should return the correct color for a value clearly within a defined range', () => {
+      expect(getColorForNumber(5, sampleRanges)).toBe('blue');
+      expect(getColorForNumber(15, sampleRanges)).toBe('green');
+      expect(getColorForNumber(25, sampleRanges)).toBe('red'); // Last range is open-ended
+    });
+
+    it('should return the correct color for values in different ranges', () => {
+      expect(getColorForNumber(0, sampleRanges)).toBe('blue');
+      expect(getColorForNumber(10, sampleRanges)).toBe('green');
+      expect(getColorForNumber(20, sampleRanges)).toBe('red');
+    });
+  });
+
+  describe('boundary conditions', () => {
+    it('should return the correct color for a value equal to the start of a range', () => {
+      expect(getColorForNumber(0, sampleRanges)).toBe('blue');
+      expect(getColorForNumber(10, sampleRanges)).toBe('green');
+      expect(getColorForNumber(20, sampleRanges)).toBe('red');
+    });
+
+    it('should return the correct color for a value just below the start of a subsequent range', () => {
+      expect(getColorForNumber(9.99, sampleRanges)).toBe('blue');
+      expect(getColorForNumber(19.99, sampleRanges)).toBe('green');
+    });
+  });
+
+  describe('values outside ranges', () => {
+    it('should return undefined for a value below the start of the first range', () => {
+      expect(getColorForNumber(-5, sampleRanges)).toBeUndefined();
+      expect(getColorForNumber(-0.01, sampleRanges)).toBeUndefined();
+    });
+
+    it('should return the last ranges color for a value above the start of the last range (last range is open-ended)', () => {
+      expect(getColorForNumber(30, sampleRanges)).toBe('red');
+      expect(getColorForNumber(1000, sampleRanges)).toBe('red');
+    });
+
+    it('should return undefined if value is below the start of the first range (with negative ranges)', () => {
+        expect(getColorForNumber(-30, sampleRangesWithNegatives)).toBeUndefined();
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should return undefined when given an empty ranges array', () => {
+      expect(getColorForNumber(5, [])).toBeUndefined();
+    });
+
+    it('should handle overlapping ranges (first applicable sorted range wins)', () => {
+      const overlappingRanges: Range[] = [
+        { start: 0, color: 'blue' },
+        { start: 5, color: 'yellow' }, // Overlaps with blue from 5-9.99...
+        { start: 10, color: 'green' },
+      ];
+      // Function sorts them: 0-blue, 5-yellow, 10-green
+      expect(getColorForNumber(3, overlappingRanges)).toBe('blue');
+      expect(getColorForNumber(5, overlappingRanges)).toBe('yellow'); // 5 is >= 5 (yellow) and < 10 (green)
+      expect(getColorForNumber(7, overlappingRanges)).toBe('yellow');
+      expect(getColorForNumber(10, overlappingRanges)).toBe('green');
+
+      const overlappingRanges2: Range[] = [
+        { start: 10, color: 'green' },
+        { start: 0, color: 'blue' }, // Unsorted
+        { start: 5, color: 'yellow' },
+      ];
+      // Sorted: 0-blue, 5-yellow, 10-green
+      expect(getColorForNumber(6, overlappingRanges2)).toBe('yellow');
+    });
+
+    it('should handle ranges that are not pre-sorted', () => {
+      const unsortedRanges: Range[] = [
+        { start: 20, color: 'red' },
+        { start: 0, color: 'blue' },
+        { start: 10, color: 'green' },
+      ];
+      expect(getColorForNumber(5, unsortedRanges)).toBe('blue');
+      expect(getColorForNumber(15, unsortedRanges)).toBe('green');
+      expect(getColorForNumber(25, unsortedRanges)).toBe('red');
+    });
+
+    it('should correctly handle negative numbers as values and in range definitions', () => {
+      expect(getColorForNumber(-15, sampleRangesWithNegatives)).toBe('purple'); // Corrected: was 'orange'
+      expect(getColorForNumber(-20, sampleRangesWithNegatives)).toBe('purple');
+      expect(getColorForNumber(-5, sampleRangesWithNegatives)).toBe('orange'); // -5 is >= -10 (orange) and < 0 (yellow)
+      expect(getColorForNumber(0, sampleRangesWithNegatives)).toBe('yellow');
+      expect(getColorForNumber(5, sampleRangesWithNegatives)).toBe('yellow'); // Last range is open-ended
+    });
+
+    it('should handle a single range correctly', () => {
+        const singleRange: Range[] = [{ start: 100, color: 'pink' }];
+        expect(getColorForNumber(50, singleRange)).toBeUndefined();
+        expect(getColorForNumber(100, singleRange)).toBe('pink');
+        expect(getColorForNumber(200, singleRange)).toBe('pink');
+    });
+
+    it('should handle ranges with identical start points (first one in sorted list wins)', () => {
+        const rangesForSameStartTest: Range[] = [
+            { start: 0, color: 'blue' },
+            { start: 10, color: 'green' },
+            { start: 10, color: 'black' },
+            { start: 20, color: 'red' }
+        ];
+        expect(getColorForNumber(10, rangesForSameStartTest)).toBe('black');
+        expect(getColorForNumber(15, rangesForSameStartTest)).toBe('black');
+
+         const rangesForSameStartTest2: Range[] = [
+            { start: 0, color: 'blue' },
+            { start: 10, color: 'black' },
+            { start: 10, color: 'green' },
+            { start: 20, color: 'red' }
+        ];
+        expect(getColorForNumber(10, rangesForSameStartTest2)).toBe('green');
+        expect(getColorForNumber(15, rangesForSameStartTest2)).toBe('green');
+    });
+  });
+});

--- a/src/utils/get_timeline_events.test.ts
+++ b/src/utils/get_timeline_events.test.ts
@@ -1,0 +1,452 @@
+import { getTimelineEvents, getReviewMessage, Activity } from './get_timeline_events';
+
+// --- Mock GraphQL Types ---
+// These are simplified versions of @octokit/graphql-schema types
+// including only the fields used by the functions being tested.
+
+interface MockActor {
+  login: string;
+  avatarUrl?: string; // Optional as it's used by Activity but not all events provide it directly
+}
+
+interface MockAssignee {
+  __typename?: 'User' | 'Bot' | 'Mannequin' | 'Organization'; // Example assignable types
+  login: string;
+  avatarUrl?: string;
+}
+
+
+interface MockPullRequestReviewCommentConnection {
+  totalCount: number;
+}
+
+interface MockPullRequestReview {
+  __typename: 'PullRequestReview';
+  author?: MockActor | null;
+  bodyText: string;
+  state: "APPROVED" | "CHANGES_REQUESTED" | "COMMENTED" | "DISMISSED" | "PENDING" | string; // string for other states
+  comments: MockPullRequestReviewCommentConnection;
+  updatedAt: string; // Assuming ISO date string
+  createdAt: string; // Though getReviewMessage doesn't use it, it's common
+}
+
+interface MockAssignedEvent {
+  __typename: 'AssignedEvent';
+  assignee?: MockAssignee | null; // Can be Actor or specific types like User, Bot etc.
+  createdAt: string;
+}
+
+interface MockCommit {
+  abbreviatedOid: string;
+  authoredDate: string;
+}
+
+interface MockPullRequestCommit {
+  __typename: 'PullRequestCommit';
+  commit: MockCommit;
+  // Note: PullRequestCommit events don't have a direct author field in the same way reviews do.
+  // The author is on commit.committer or commit.author, but the function doesn't use it directly for the activity author.
+}
+
+interface MockIssueComment {
+  __typename: 'IssueComment';
+  author?: MockActor | null;
+  bodyText: string;
+  updatedAt: string;
+  createdAt: string;
+}
+
+interface MockUnknownEvent {
+  __typename: 'UnknownEvent' | 'LabeledEvent' | 'MergedEvent'; // Example of other types
+  createdAt?: string; // Some events might have these
+  updatedAt?: string;
+}
+
+
+type MockPullRequestTimelineItem =
+  | MockPullRequestReview
+  | MockAssignedEvent
+  | MockPullRequestCommit
+  | MockIssueComment
+  | MockUnknownEvent;
+
+interface MockPullRequestTimelineItemsConnection {
+  nodes?: (MockPullRequestTimelineItem | null)[] | null;
+  totalCount?: number;
+}
+
+interface MockPullRequest {
+  timelineItems?: MockPullRequestTimelineItemsConnection | null;
+}
+
+// --- Tests for getReviewMessage ---
+
+describe('getReviewMessage', () => {
+  const mockReviewBase: Omit<MockPullRequestReview, 'state' | 'comments' | 'bodyText'> = {
+    __typename: 'PullRequestReview',
+    author: { login: 'testuser', avatarUrl: 'url' },
+    updatedAt: '2023-01-01T12:00:00Z',
+    createdAt: '2023-01-01T11:00:00Z',
+  };
+
+  describe('APPROVED state', () => {
+    it('should return "Approved" if 0 comments', () => {
+      const review: MockPullRequestReview = {
+        ...mockReviewBase,
+        state: 'APPROVED',
+        comments: { totalCount: 0 },
+        bodyText: '',
+      };
+      expect(getReviewMessage(review as any)).toBe('Approved');
+    });
+
+    it('should return "Approved with X comments" if >0 comments', () => {
+      const review: MockPullRequestReview = {
+        ...mockReviewBase,
+        state: 'APPROVED',
+        comments: { totalCount: 3 },
+        bodyText: '',
+      };
+      expect(getReviewMessage(review as any)).toBe('Approved with 3 comments');
+    });
+  });
+
+  describe('CHANGES_REQUESTED state', () => {
+    it('should include bodyText', () => {
+      const review: MockPullRequestReview = {
+        ...mockReviewBase,
+        state: 'CHANGES_REQUESTED',
+        comments: { totalCount: 1 }, // Comments might exist
+        bodyText: 'Please fix this.',
+      };
+      expect(getReviewMessage(review as any)).toBe('Changes Requested: Please fix this.');
+    });
+     it('should include bodyText even if empty', () => {
+      const review: MockPullRequestReview = {
+        ...mockReviewBase,
+        state: 'CHANGES_REQUESTED',
+        comments: { totalCount: 0 },
+        bodyText: '',
+      };
+      expect(getReviewMessage(review as any)).toBe('Changes Requested: ');
+    });
+  });
+
+  describe('COMMENTED state', () => {
+    it('should return "Left a comment" if 0 body comments (totalCount refers to line comments)', () => {
+      // The function uses review.comments.totalCount, which usually means review comments on lines of code.
+      // A "COMMENTED" review state without a main review body comment but with line comments.
+      const review: MockPullRequestReview = {
+        ...mockReviewBase,
+        state: 'COMMENTED',
+        comments: { totalCount: 0 }, // Let's assume this means no line comments for this interpretation
+        bodyText: '', // No main review comment body
+      };
+      // If totalCount is 0, it means "Left a comment" (implying the review itself is a comment action)
+      expect(getReviewMessage(review as any)).toBe('Left a comment');
+    });
+
+    it('should return "Left X comments" if >0 comments', () => {
+      const review: MockPullRequestReview = {
+        ...mockReviewBase,
+        state: 'COMMENTED',
+        comments: { totalCount: 5 },
+        bodyText: 'General feedback.', // Body text might or might not be there
+      };
+      expect(getReviewMessage(review as any)).toBe('Left 5 comments');
+    });
+  });
+
+  describe('Other states', () => {
+    it('should return "reviewed" for DISMISSED state', () => {
+      const review: MockPullRequestReview = {
+        ...mockReviewBase,
+        state: 'DISMISSED',
+        comments: { totalCount: 0 },
+        bodyText: '',
+      };
+      expect(getReviewMessage(review as any)).toBe('reviewed');
+    });
+
+    it('should return "reviewed" for PENDING state', () => {
+      const review: MockPullRequestReview = {
+        ...mockReviewBase,
+        state: 'PENDING',
+        comments: { totalCount: 0 },
+        bodyText: '',
+      };
+      expect(getReviewMessage(review as any)).toBe('reviewed');
+    });
+
+    it('should return "reviewed" for any other string state', () => {
+      const review: MockPullRequestReview = {
+        ...mockReviewBase,
+        state: 'UNKNOWN_CUSTOM_STATE',
+        comments: { totalCount: 0 },
+        bodyText: '',
+      };
+      expect(getReviewMessage(review as any)).toBe('reviewed');
+    });
+  });
+});
+
+// --- Tests for getTimelineEvents ---
+
+describe('getTimelineEvents', () => {
+  const mockAuthor: MockActor = { login: 'testuser', avatarUrl: 'http://example.com/avatar.png' };
+  const mockAssigneeUser: MockAssignee = { __typename: 'User', login: 'assigneeUser', avatarUrl: 'http://example.com/assignee.png' };
+
+  it('should handle empty timelineItems.nodes gracefully', () => {
+    const pr: MockPullRequest = {
+      timelineItems: { nodes: [], totalCount: 0 },
+    };
+    const result = getTimelineEvents(pr as any);
+    // The grouping logic `activities[0]` will cause error if activities is empty.
+    // Based on current code: if activities is empty, `groupedActivities` will be `[undefined]` then filtered to `[]`.
+    expect(result.activities).toEqual([]);
+    expect(result.totalEvents).toBe(0);
+  });
+
+  it('should handle null timelineItems.nodes', () => {
+    const pr: MockPullRequest = {
+      timelineItems: { nodes: null, totalCount: 0 },
+    };
+    const result = getTimelineEvents(pr as any);
+    expect(result.activities).toEqual([]);
+    expect(result.totalEvents).toBe(0);
+  });
+
+  it('should handle null pr.timelineItems', () => {
+    const pr: MockPullRequest = {
+      timelineItems: null,
+    };
+    const result = getTimelineEvents(pr as any);
+    expect(result.activities).toEqual([]);
+    expect(result.totalEvents).toBeUndefined(); // totalCount would be undefined
+  });
+
+  it('should filter out null items in timelineItems.nodes', () => {
+    const pr: MockPullRequest = {
+      timelineItems: {
+        nodes: [
+          null,
+          {
+            __typename: 'AssignedEvent',
+            assignee: mockAssigneeUser,
+            createdAt: '2023-01-01T10:00:00Z',
+          } as MockAssignedEvent,
+          null,
+        ],
+        totalCount: 1, // Count of actual event
+      },
+    };
+    const result = getTimelineEvents(pr as any);
+    expect(result.activities.length).toBe(1);
+    expect(result.activities[0].type).toBe('AssignedEvent');
+    expect(result.totalEvents).toBe(1);
+  });
+
+  describe('Event type handling', () => {
+    it('should process AssignedEvent correctly', () => {
+      const pr: MockPullRequest = {
+        timelineItems: {
+          nodes: [
+            {
+              __typename: 'AssignedEvent',
+              assignee: mockAssigneeUser,
+              createdAt: '2023-01-01T10:00:00Z',
+            } as MockAssignedEvent,
+          ],
+          totalCount: 1,
+        },
+      };
+      const result = getTimelineEvents(pr as any);
+      expect(result.activities.length).toBe(1);
+      const activity = result.activities[0];
+      expect(activity.type).toBe('AssignedEvent');
+      expect(activity.message).toBe('Assigned to assigneeUser');
+      expect(activity.author?.login).toBe('assigneeUser');
+      expect(activity.date).toBe('2023-01-01T10:00:00Z');
+    });
+
+    it('should process PullRequestReview correctly', () => {
+      const reviewItem: MockPullRequestReview = {
+        __typename: 'PullRequestReview',
+        author: mockAuthor,
+        state: 'APPROVED',
+        comments: { totalCount: 0 },
+        bodyText: '',
+        updatedAt: '2023-01-02T10:00:00Z',
+        createdAt: '2023-01-02T09:00:00Z',
+      };
+      const pr: MockPullRequest = {
+        timelineItems: { nodes: [reviewItem], totalCount: 1 },
+      };
+      const result = getTimelineEvents(pr as any);
+      expect(result.activities.length).toBe(1);
+      const activity = result.activities[0];
+      expect(activity.type).toBe('PullRequestReview');
+      expect(activity.message).toBe('Approved'); // from getReviewMessage
+      expect(activity.author?.login).toBe('testuser');
+      expect(activity.date).toBe('2023-01-02T10:00:00Z');
+    });
+
+    it('should process PullRequestCommit correctly', () => {
+      const commitItem: MockPullRequestCommit = {
+        __typename: 'PullRequestCommit',
+        commit: {
+          abbreviatedOid: 'abc1234',
+          authoredDate: '2023-01-03T10:00:00Z',
+        },
+      };
+      const pr: MockPullRequest = {
+        timelineItems: { nodes: [commitItem], totalCount: 1 },
+      };
+      const result = getTimelineEvents(pr as any);
+      expect(result.activities.length).toBe(1);
+      const activity = result.activities[0];
+      expect(activity.type).toBe('PullRequestCommit');
+      expect(activity.message).toBe('abc1234');
+      expect(activity.date).toBe('2023-01-03T10:00:00Z');
+      expect(activity.author).toBeUndefined(); // No direct author on this activity
+    });
+
+    it('should process IssueComment correctly', () => {
+      const commentItem: MockIssueComment = {
+        __typename: 'IssueComment',
+        author: mockAuthor,
+        bodyText: 'This is a comment.',
+        updatedAt: '2023-01-04T10:00:00Z',
+        createdAt: '2023-01-04T09:00:00Z',
+      };
+      const pr: MockPullRequest = {
+        timelineItems: { nodes: [commentItem], totalCount: 1 },
+      };
+      const result = getTimelineEvents(pr as any);
+      expect(result.activities.length).toBe(1);
+      const activity = result.activities[0];
+      expect(activity.type).toBe('IssueComment');
+      expect(activity.message).toBe('This is a comment.');
+      expect(activity.author?.login).toBe('testuser');
+      expect(activity.date).toBe('2023-01-04T10:00:00Z');
+    });
+
+    it('should handle unknown event types with a default message', () => {
+      const unknownItem: MockUnknownEvent = {
+        __typename: 'LabeledEvent', // An example of an unhandled type
+        createdAt: '2023-01-05T10:00:00Z',
+      };
+      const pr: MockPullRequest = {
+        timelineItems: { nodes: [unknownItem], totalCount: 1 },
+      };
+      const result = getTimelineEvents(pr as any);
+      expect(result.activities.length).toBe(1);
+      const activity = result.activities[0];
+      expect(activity.type).toBe('LabeledEvent');
+      expect(activity.message).toBe('Unknown event');
+      // The date for unknown events is currently set to '', which might be intended or not
+      expect(activity.date).toBe('');
+    });
+     it('should handle events with missing optional author gracefully', () => {
+      const reviewItem: MockPullRequestReview = {
+        __typename: 'PullRequestReview',
+        author: null, // Missing author
+        state: 'COMMENTED',
+        comments: { totalCount: 1 },
+        bodyText: 'A comment',
+        updatedAt: '2023-01-02T11:00:00Z',
+        createdAt: '2023-01-02T11:00:00Z',
+      };
+       const pr: MockPullRequest = {
+        timelineItems: { nodes: [reviewItem], totalCount: 1 },
+      };
+      const result = getTimelineEvents(pr as any);
+      expect(result.activities.length).toBe(1);
+      const activity = result.activities[0];
+      expect(activity.author).toBeNull();
+    });
+  });
+
+  describe('Commit grouping logic', () => {
+    const commit1: MockPullRequestCommit = {
+      __typename: 'PullRequestCommit',
+      commit: { abbreviatedOid: 'c1', authoredDate: '2023-01-03T10:00:00Z' },
+    };
+    const commit2: MockPullRequestCommit = {
+      __typename: 'PullRequestCommit',
+      commit: { abbreviatedOid: 'c2', authoredDate: '2023-01-03T11:00:00Z' },
+    };
+    const commit3: MockPullRequestCommit = {
+      __typename: 'PullRequestCommit',
+      commit: { abbreviatedOid: 'c3', authoredDate: '2023-01-03T12:00:00Z' },
+    };
+    const review: MockPullRequestReview = {
+        __typename: 'PullRequestReview',
+        author: mockAuthor,
+        state: 'COMMENTED',
+        comments: { totalCount: 1 },
+        bodyText: 'Review after commits',
+        updatedAt: '2023-01-03T13:00:00Z',
+        createdAt: '2023-01-03T13:00:00Z',
+      };
+
+    it('should group multiple consecutive PullRequestCommit events', () => {
+      const pr: MockPullRequest = {
+        timelineItems: { nodes: [commit1, commit2, commit3], totalCount: 3 },
+      };
+      const result = getTimelineEvents(pr as any);
+      expect(result.activities.length).toBe(1);
+      const activity = result.activities[0];
+      expect(activity.type).toBe('PullRequestCommit');
+      expect(activity.message).toBe('c1; c2; c3');
+      expect(activity.date).toBe('2023-01-03T12:00:00Z'); // Date of the last commit in group
+    });
+
+    it('should not group non-consecutive PullRequestCommit events', () => {
+      const pr: MockPullRequest = {
+        timelineItems: { nodes: [commit1, review, commit2], totalCount: 3 },
+      };
+      const result = getTimelineEvents(pr as any);
+      expect(result.activities.length).toBe(3);
+      expect(result.activities[0].message).toBe('c1');
+      expect(result.activities[1].type).toBe('PullRequestReview');
+      expect(result.activities[2].message).toBe('c2');
+    });
+
+    it('should handle a single PullRequestCommit event (no grouping needed)', () => {
+      const pr: MockPullRequest = {
+        timelineItems: { nodes: [commit1], totalCount: 1 },
+      };
+      const result = getTimelineEvents(pr as any);
+      expect(result.activities.length).toBe(1);
+      expect(result.activities[0].message).toBe('c1');
+    });
+
+    it('should correctly group commits when they are the first events', () => {
+      const pr: MockPullRequest = {
+        timelineItems: { nodes: [commit1, commit2, review], totalCount: 3 },
+      };
+      const result = getTimelineEvents(pr as any);
+      expect(result.activities.length).toBe(2);
+      expect(result.activities[0].type).toBe('PullRequestCommit');
+      expect(result.activities[0].message).toBe('c1; c2');
+      expect(result.activities[0].date).toBe('2023-01-03T11:00:00Z');
+      expect(result.activities[1].type).toBe('PullRequestReview');
+    });
+  });
+
+   it('should handle a PR with only one event', () => {
+    const assignEvent: MockAssignedEvent = {
+      __typename: 'AssignedEvent',
+      assignee: mockAssigneeUser,
+      createdAt: '2023-01-01T10:00:00Z',
+    };
+    const pr: MockPullRequest = {
+      timelineItems: { nodes: [assignEvent], totalCount: 1 },
+    };
+    const result = getTimelineEvents(pr as any);
+    expect(result.activities.length).toBe(1);
+    expect(result.activities[0].type).toBe('AssignedEvent');
+    expect(result.totalEvents).toBe(1);
+  });
+});

--- a/src/utils/get_timeline_events.ts
+++ b/src/utils/get_timeline_events.ts
@@ -61,23 +61,30 @@ export const getTimelineEvents = (pr: PullRequest) => {
     }
   });
 
-  const groupedActivities = activities
-    .reduce(
-      (acc, activity) => {
-        if (
-          acc[acc.length - 1].type === activity.type &&
-          activity.type === 'PullRequestCommit'
-        ) {
-          acc[acc.length - 1].message += `; ${activity.message}`;
-          acc[acc.length - 1].date = activity.date; // Use the latest date
-        } else {
-          acc.push(activity);
-        }
-        return acc;
-      },
-      [activities[0]],
-    )
-    .filter(Boolean) as Activity[];
+  if (activities.length === 0) {
+    return {
+      activities: [],
+      totalEvents: pr.timelineItems?.totalCount,
+    };
+  }
+
+  const groupedActivities = activities.reduce((acc, activity) => {
+    if (acc.length === 0) {
+      acc.push(activity);
+    } else {
+      const lastActivity = acc[acc.length - 1];
+      if (
+        lastActivity.type === activity.type &&
+        activity.type === 'PullRequestCommit'
+      ) {
+        lastActivity.message += `; ${activity.message}`;
+        lastActivity.date = activity.date; // Use the latest date
+      } else {
+        acc.push(activity);
+      }
+    }
+    return acc;
+  }, [] as Activity[]);
 
   return {
     activities: groupedActivities,
@@ -85,7 +92,7 @@ export const getTimelineEvents = (pr: PullRequest) => {
   };
 };
 
-function getReviewMessage(review: PullRequestReview) {
+export function getReviewMessage(review: PullRequestReview) {
   const commentCount = review.comments.totalCount;
   switch (review.state) {
     case 'APPROVED':

--- a/src/utils/search_string.test.ts
+++ b/src/utils/search_string.test.ts
@@ -1,0 +1,205 @@
+import { search } from './search_string';
+
+describe('search object', () => {
+  describe('search.add', () => {
+    it('should add a key-value pair to an empty string', () => {
+      expect(search.add('', 'author', 'john')).toBe('author:john');
+    });
+
+    it('should add a key-value pair to a non-empty string', () => {
+      expect(search.add('status:open', 'author', 'john')).toBe('status:open author:john');
+    });
+
+    it('should replace existing key-value pairs for the same key', () => {
+      expect(search.add('author:jane status:closed', 'author', 'john')).toBe('status:closed author:john');
+      expect(search.add('author:jane author:doe', 'author', 'john')).toBe('author:john'); // All old 'author' removed
+    });
+
+    it('should add a key-value pair at a specific position', () => {
+      expect(search.add('status:open sort:date', 'author', 'john', 1)).toBe('status:open author:john sort:date');
+      expect(search.add('status:open sort:date', 'author', 'john', 0)).toBe('author:john status:open sort:date');
+      expect(search.add('status:open sort:date', 'author', 'john', 2)).toBe('status:open sort:date author:john');
+    });
+
+    it('should handle leading/trailing spaces in the input string q (they are normalized by filter(Boolean))', () => {
+      expect(search.add(' status:open  ', 'author', 'john')).toBe('status:open author:john');
+      expect(search.add(' author:old  status:open ', 'author', 'john')).toBe('status:open author:john');
+    });
+
+    it('should add correctly when value contains spaces (no special handling by add, creates "key:value with space")', () => {
+      expect(search.add('', 'name', 'John Doe')).toBe('name:John Doe'); // Produces a single string "name:John Doe"
+      expect(search.add('repo:foo', 'name', 'John Doe')).toBe('repo:foo name:John Doe');
+    });
+  });
+
+  describe('search.remove', () => {
+    it('should remove a key-value pair from a string', () => {
+      expect(search.remove('author:john status:open', 'author')).toBe('status:open');
+    });
+
+    it('should attempt to remove a key that doesn\'t exist (string remains unchanged)', () => {
+      expect(search.remove('status:open', 'author')).toBe('status:open');
+      expect(search.remove('  status:open  ', 'author')).toBe('status:open'); // With filter(Boolean)
+    });
+
+    it('should remove a key when multiple different keys exist', () => {
+      expect(search.remove('author:john status:open sort:date', 'status')).toBe('author:john sort:date');
+    });
+
+    it('should remove all occurrences of a key if it exists multiple times', () => {
+      expect(search.remove('author:name1 author:name2 status:open', 'author')).toBe('status:open');
+    });
+
+    it('should handle extra spaces between tokens when removing (they are normalized by filter(Boolean))', () => {
+      expect(search.remove('author:john   status:open', 'author')).toBe('status:open');
+      expect(search.remove('  author:john status:open', 'author')).toBe('status:open');
+    });
+  });
+
+  describe('search.has', () => {
+    it('should return true if the exact key-value pair exists (value has no spaces)', () => {
+      expect(search.has('author:john status:open', 'author', 'john')).toBe(true);
+    });
+
+    it('should return false if the key-value pair does not exist', () => {
+      expect(search.has('author:john status:open', 'reviewer', 'jane')).toBe(false);
+    });
+
+    it('should return false if the key exists but with a different value', () => {
+      expect(search.has('author:john status:open', 'author', 'jane')).toBe(false);
+    });
+
+    it('should return false when checking in an empty string', () => {
+      expect(search.has('', 'author', 'john')).toBe(false);
+    });
+
+    it('should handle values with spaces (split behavior means it wont find "key:value with space" as one token)', () => {
+      // search.add creates "name:John Doe" as a single string.
+      // However, search.has will split "name:John Doe" into "name:John" and "Doe" if it's part of a larger query string
+      // or even if it's the whole query string.
+      // Thus, it cannot find "name:John Doe" as a single token.
+      expect(search.has('name:John Doe repo:foo', 'name', 'John Doe')).toBe(false); // This is false because "name:John Doe" is not a token after "John Doe".split by space
+      expect(search.has('name:John Doe', 'name', 'John Doe')).toBe(false); // Query "name:John Doe" -> tokens "name:John", "Doe". Target "name:John Doe". No match.
+
+      // It would find "name:John" if that was the intended key-value pair and the query reflected that.
+      expect(search.has('name:John repo:foo', 'name', 'John')).toBe(true);
+    });
+  });
+
+  describe('search.get', () => {
+    it('should get a value for a key that exists', () => {
+      expect(search.get('author:john status:open', 'author')).toBe('john');
+    });
+
+    it('should return an empty string if the key doesn\'t exist', () => {
+      expect(search.get('status:open', 'author')).toBe('');
+    });
+
+    it('should return the first value if the key is present multiple times', () => {
+      expect(search.get('author:name1 author:name2 status:open', 'author')).toBe('name1');
+    });
+
+    it('should handle values with colons correctly (returns everything after first colon)', () => {
+      expect(search.get('url:http://example.com', 'url')).toBe('http://example.com');
+      expect(search.get('config:key:value', 'config')).toBe('key:value');
+    });
+     it('should correctly get value if value contains spaces (gets first part before space due to split)', () => {
+      // If q = "name:John Doe", add would have created this as one string.
+      // get will split it into "name:John", "Doe".
+      // find(token => token.startsWith("name:")) will find "name:John".
+      // substring("name".length + 1) will give "John".
+      expect(search.get('name:John Doe', 'name')).toBe('John');
+      expect(search.get('name:John Doe repo:test', 'name')).toBe('John');
+    });
+  });
+
+  describe('search.getKeys', () => {
+    it('should get all keys from a string with multiple key-value pairs', () => {
+      expect(search.getKeys('author:john status:open sort:date')).toEqual(['author', 'status', 'sort']);
+    });
+
+    it('should get keys from a string with one key-value pair', () => {
+      expect(search.getKeys('author:john')).toEqual(['author']);
+    });
+
+    it('should return an empty array if the string has no key-value pairs (no colons)', () => {
+      expect(search.getKeys('open due soon')).toEqual([]);
+    });
+
+    it('should return an empty array for an empty string', () => {
+      expect(search.getKeys('')).toEqual([]);
+    });
+
+    it('should correctly parse keys even if there are tokens without colons', () => {
+      expect(search.getKeys('author:john open status:closed sort:date urgent')).toEqual(['author', 'status', 'sort']);
+    });
+     it('should handle keys when values have spaces (keys are up to colon)', () => {
+      expect(search.getKeys('name:John Doe repo:test')).toEqual(['name', 'repo']); // "Doe" is not a key
+    });
+  });
+
+  describe('search.getValues', () => {
+    it('should get all values for a specific key when it appears multiple times', () => {
+      expect(search.getValues('author:name1 author:name2 status:open', 'author')).toEqual(['name1', 'name2']);
+    });
+
+    it('should get values for a key that appears once', () => {
+      expect(search.getValues('author:john status:open', 'author')).toEqual(['john']);
+    });
+
+    it('should return an empty array if the key does not exist', () => {
+      expect(search.getValues('status:open', 'author')).toEqual([]);
+    });
+
+    it('should return an empty array for an empty string', () => {
+      expect(search.getValues('', 'author')).toEqual([]);
+    });
+
+    it('should correctly parse values which themselves contain colons', () => {
+      expect(search.getValues('url:http://example.com label:bug:critical', 'url')).toEqual(['http://example.com']);
+      expect(search.getValues('url:http://example.com label:bug:critical', 'label')).toEqual(['bug:critical']);
+    });
+    it('should get values if values contain spaces (gets first part before space)', () => {
+      // If q = "name:John Doe name:Jane Eyre" (manually constructed as add would replace)
+      // tokens = ["name:John", "Doe", "name:Jane", "Eyre"]
+      // filter(token.startsWith("name:")) -> ["name:John", "name:Jane"]
+      // map(token.substring("name".length+1)) -> ["John", "Jane"]
+      expect(search.getValues('name:John Doe name:Jane Eyre', 'name')).toEqual(['John', 'Jane']);
+    });
+  });
+
+  describe('General considerations and space handling (after filter(Boolean))', () => {
+    it('should handle queries with multiple spaces between tokens', () => {
+      expect(search.add('author:jane   status:open', 'author', 'john')).toBe('status:open author:john');
+      expect(search.remove('author:john   status:open', 'author')).toBe('status:open');
+      expect(search.has('author:john   status:open', 'author', 'john')).toBe(true);
+      expect(search.has('author:john   status:open', 'status', 'open')).toBe(true);
+      expect(search.get('author:john   status:open', 'author')).toBe('john');
+      expect(search.getKeys('author:john   status:open')).toEqual(['author', 'status']);
+      expect(search.getValues('author:john   status:open', 'author')).toEqual(['john']);
+    });
+
+    it('should handle queries with leading/trailing spaces', () => {
+      const q = ' author:john status:open ';
+      expect(search.add(q, 'repo', 'mine')).toBe('author:john status:open repo:mine');
+      expect(search.add(q, 'author', 'new')).toBe('status:open author:new');
+      expect(search.remove(q, 'author')).toBe('status:open');
+      expect(search.has(q, 'author', 'john')).toBe(true);
+      expect(search.get(q, 'status')).toBe('open');
+      expect(search.getKeys(q)).toEqual(['author', 'status']);
+      expect(search.getValues(q, 'author')).toEqual(['john']);
+    });
+
+    it('should handle tokens without colons (plain keywords)', () => {
+        const q = 'author:john open review:needed urgent';
+        expect(search.add(q, 'label', 'bug')).toBe('author:john open review:needed urgent label:bug');
+        expect(search.remove(q, 'review')).toBe('author:john open urgent');
+        expect(search.has(q, 'author', 'john')).toBe(true);
+        expect(search.has(q, 'label', 'bug')).toBe(false);
+        expect(search.get(q, 'author')).toBe('john');
+        expect(search.get(q, 'urgent')).toBe('');
+        expect(search.getKeys(q)).toEqual(['author', 'review']);
+        expect(search.getValues(q, 'author')).toEqual(['john']);
+    });
+  });
+});

--- a/src/utils/search_string.ts
+++ b/src/utils/search_string.ts
@@ -1,6 +1,6 @@
 export const search = {
   add: (q: string, key: string, value: string, position?: number) => {
-    const tokens = q.split(' ');
+    const tokens = q.split(' ').filter(Boolean); // Filter out empty strings
     const newTokens = tokens.filter((token) => !token.startsWith(`${key}:`));
     if (position !== undefined) {
       newTokens.splice(position, 0, `${key}:${value}`);
@@ -10,29 +10,29 @@ export const search = {
     return newTokens.join(' ');
   },
   remove: (q: string, key: string) => {
-    const tokens = q.split(' ');
+    const tokens = q.split(' ').filter(Boolean); // Filter out empty strings
     const newTokens = tokens.filter((token) => !token.startsWith(`${key}:`));
     return newTokens.join(' ');
   },
   has: (q: string, key: string, value: string) => {
-    const tokens = q.split(' ');
+    const tokens = q.split(' ').filter(Boolean); // Filter out empty strings
     return tokens.some((token) => token === `${key}:${value}`);
   },
   get: (q: string, key: string) => {
-    const tokens = q.split(' ');
+    const tokens = q.split(' ').filter(Boolean); // Filter out empty strings
     const token = tokens.find((token) => token.startsWith(`${key}:`));
-    return token ? token.split(':')[1] : '';
+    return token ? token.substring(key.length + 1) : '';
   },
   getKeys: (q: string) => {
-    const tokens = q.split(' ');
+    const tokens = q.split(' ').filter(Boolean); // Filter out empty strings
     return tokens
       .filter((token) => token.includes(':'))
       .map((token) => token.split(':')[0]);
   },
   getValues: (q: string, key: string) => {
-    const tokens = q.split(' ');
+    const tokens = q.split(' ').filter(Boolean); // Filter out empty strings
     return tokens
       .filter((token) => token.startsWith(`${key}:`))
-      .map((token) => token.split(':')[1]);
+      .map((token) => token.substring(key.length + 1));
   },
 };


### PR DESCRIPTION
This commit introduces comprehensive unit tests for several utility functions in the `src/utils` directory.

The following files and functions are now covered by tests:
- `src/utils/common.ts`:
    - `getUniqueValues`: Tested with primitives and objects, including various edge cases.
    - `groupBy`: Tested for different grouping scenarios and edge cases.
- `src/utils/get_color_for_number.ts`:
    - `getColorForNumber`: Tested with values in, out, and at the boundaries of color ranges.
- `src/utils/get_timeline_events.ts`:
    - `getReviewMessage`: Tested for all review states and comment variations.
    - `getTimelineEvents`: Tested for various event types, commit grouping logic, and edge cases. A bug in commit grouping was identified and fixed during test development. The `getReviewMessage` function was also exported.
- `src/utils/search_string.ts`:
    - All methods of the `search` object (`add`, `remove`, `has`, `get`, `getKeys`, `getValues`) were tested. Issues related to space handling and values containing colons were identified and fixed in the source code.

Tests for `src/utils/events.ts` and `src/utils/graphql_proxy.ts` were reviewed and deferred, as they are better suited for integration testing.

All new and existing tests pass.